### PR TITLE
Add support for correlating DRX8 data

### DIFF
--- a/createConfigFile.py
+++ b/createConfigFile.py
@@ -300,9 +300,11 @@ def main(args):
                 
                 ## Read in the first few frames to get the start time
                 try:
+                    ### Assume it's normal DRX
                     is_drx8 = False
                     frames = [rdr.read_frame(fh) for i in range(1024)]
-                except:
+                except errors.SyncError:
+                    ### Nope, it's DRX8
                     fh.seek(-drx.FRAME_SIZE, 1)
                     rdr = drx8
                     frames = [rdr.read_frame(fh) for i in range(1024)]

--- a/createConfigFile.py
+++ b/createConfigFile.py
@@ -301,11 +301,11 @@ def main(args):
                 ## Read in the first few frames to get the start time
                 try:
                     ### Assume it's normal DRX
-                    is_drx8 = False
+                    rdr = drx
                     frames = [rdr.read_frame(fh) for i in range(1024)]
                 except errors.SyncError:
                     ### Nope, it's DRX8
-                    fh.seek(-drx.FRAME_SIZE, 1)
+                    fh.seek(-2*rdr.FRAME_SIZE, 1)
                     rdr = drx8
                     frames = [rdr.read_frame(fh) for i in range(1024)]
                 streams = []

--- a/plotUVCoverage.py
+++ b/plotUVCoverage.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from lsl.common import stations
 from lsl.correlator import uvutils
-from lsl.reader import drx, vdif
+from lsl.reader import drx, drx8, vdif
 
 from utils import *
 
@@ -70,7 +70,7 @@ def main(args):
     print("Antennas:")
     print("  Total: %i" % len(readers))
     print("  VDIF: %i" % sum([1 for rdr in readers if rdr is vdif]))
-    print("  DRX: %i" % sum([1 for rdr in readers if rdr is drx]))
+    print("  DRX/DRX8: %i" % sum([1 for rdr in readers if rdr in (drx, drx8)]))
     print("Baselines:")
     print("  Total: %i" % (uvw.shape[0]*uvw.shape[1]))
     ## Minimum basline length

--- a/plotUVCoverage.py
+++ b/plotUVCoverage.py
@@ -70,7 +70,7 @@ def main(args):
     print("Antennas:")
     print("  Total: %i" % len(readers))
     print("  VDIF: %i" % sum([1 for rdr in readers if rdr is vdif]))
-    print("  DRX/DRX8: %i" % sum([1 for rdr in readers if rdr in (drx, drx8)]))
+    print("  DRX: %i" % sum([1 for rdr in readers if not rdr is vdif]))
     print("Baselines:")
     print("  Total: %i" % (uvw.shape[0]*uvw.shape[1]))
     ## Minimum basline length

--- a/superCorrelator.py
+++ b/superCorrelator.py
@@ -100,7 +100,7 @@ def main(args):
             junkFrame = readers[i].read_frame(fh[i], central_freq=header['OBSFREQ'], sample_rate=header['OBSBW']*2.0)
             readers[i].DATA_LENGTH = junkFrame.payload.data.size
             beam, pol = junkFrame.id
-        elif readers[i] in (drx, drx8):
+        else:
             junkFrame = readers[i].read_frame(fh[i])
             while junkFrame.header.decimation == 0:
                 junkFrame = readers[i].read_frame(fh[i])
@@ -114,7 +114,7 @@ def main(args):
         if readers[i] is vdif:
             tunepols.append( readers[i].get_thread_count(fh[i]) )
             beampols.append( tunepols[i] )
-        elif readers[i] in (drx, drx8):
+        else:
             beampols.append( max(readers[i].get_frames_per_obs(fh[i])) )
             
         skip = args.skip + foffset
@@ -145,7 +145,7 @@ def main(args):
                     cFreq1 = junkFrame.central_freq
                 else:
                     pass
-            elif readers[i] in (drx, drx8):
+            else:
                 junkFrame = readers[i].read_frame(fh[i])
                 b,t,p = junkFrame.id
                 if p == 0:
@@ -185,7 +185,7 @@ def main(args):
             
             nFramesFile[i] -= j
             
-        elif readers[i] in (drx, drx8):
+        else:
             pass
             
         # Align the files as close as possible by the time tags
@@ -277,8 +277,8 @@ def main(args):
     print(" ")
     
     nVDIFInputs = sum([1 for reader in readers if reader is vdif])
-    nDRXInputs = sum([1 for reader in readers if reader in (drx, drx8)])
-    print(f"Processing {nVDIFInputs} VDIF and {nDRXInputs} DRX/DRX8 input streams")
+    nDRXInputs = sum([1 for reader in readers if not reader is vdif])
+    print(f"Processing {nVDIFInputs} VDIF and {nDRXInputs} DRX or DRX8 input streams")
     print(" ")
     
     nFramesV = int(round(tRead*srate[0]/readers[0].DATA_LENGTH))
@@ -414,8 +414,8 @@ def main(args):
                             dataV[sid, count*readers[j].DATA_LENGTH:(count+1)*readers[j].DATA_LENGTH] = cFrame.payload.data
                             k += 1
                                                        
-                elif readers[j] in (drx, drx8):
-                    ## DRX
+                else:
+                    ## DRX/DRX8
                     k = 0
                     while k < beampols[j]*nFramesD:
                         try:

--- a/superCorrelator.py
+++ b/superCorrelator.py
@@ -25,8 +25,8 @@ from lsl.correlator import fx as fxc
 from lsl.writer import fitsidi
 from lsl.correlator.uvutils import compute_uvw
 
-from lsl.reader import drx, vdif, errors
-from lsl.reader.buffer import DRXFrameBuffer, VDIFFrameBuffer
+from lsl.reader import drx, drx8, vdif, errors
+from lsl.reader.buffer import DRXFrameBuffer, DRX8FrameBuffer, VDIFFrameBuffer
 from lsl.reader.base import CI8
 
 import jones
@@ -100,7 +100,7 @@ def main(args):
             junkFrame = readers[i].read_frame(fh[i], central_freq=header['OBSFREQ'], sample_rate=header['OBSBW']*2.0)
             readers[i].DATA_LENGTH = junkFrame.payload.data.size
             beam, pol = junkFrame.id
-        elif readers[i] is drx:
+        elif readers[i] in (drx, drx8):
             junkFrame = readers[i].read_frame(fh[i])
             while junkFrame.header.decimation == 0:
                 junkFrame = readers[i].read_frame(fh[i])
@@ -114,7 +114,7 @@ def main(args):
         if readers[i] is vdif:
             tunepols.append( readers[i].get_thread_count(fh[i]) )
             beampols.append( tunepols[i] )
-        elif readers[i] is drx:
+        elif readers[i] in (drx, drx8):
             beampols.append( max(readers[i].get_frames_per_obs(fh[i])) )
             
         skip = args.skip + foffset
@@ -145,7 +145,7 @@ def main(args):
                     cFreq1 = junkFrame.central_freq
                 else:
                     pass
-            elif readers[i] is drx:
+            elif readers[i] in (drx, drx8):
                 junkFrame = readers[i].read_frame(fh[i])
                 b,t,p = junkFrame.id
                 if p == 0:
@@ -167,6 +167,8 @@ def main(args):
             buffers.append( VDIFFrameBuffer(threads=[0,1]) )
         elif readers[i] is drx:
             buffers.append( DRXFrameBuffer(beams=[beam,], tunes=[1,2], pols=[0,1], nsegments=16) )
+        elif readers[i] is drx8:
+            buffers.append( DRX8FrameBuffer(beams=[beam,], tunes=[1,2], pols=[0,1], nsegments=16) )
     for i in range(len(filenames)):
         # Align the files as close as possible by the time tags
         if readers[i] is vdif:
@@ -183,7 +185,7 @@ def main(args):
             
             nFramesFile[i] -= j
             
-        elif readers[i] is drx:
+        elif readers[i] in (drx, drx8):
             pass
             
         # Align the files as close as possible by the time tags
@@ -275,8 +277,8 @@ def main(args):
     print(" ")
     
     nVDIFInputs = sum([1 for reader in readers if reader is vdif])
-    nDRXInputs = sum([1 for reader in readers if reader is drx])
-    print(f"Processing {nVDIFInputs} VDIF and {nDRXInputs} DRX input streams")
+    nDRXInputs = sum([1 for reader in readers if reader in (drx, drx8)])
+    print(f"Processing {nVDIFInputs} VDIF and {nDRXInputs} DRX/DRX8 input streams")
     print(" ")
     
     nFramesV = int(round(tRead*srate[0]/readers[0].DATA_LENGTH))
@@ -412,7 +414,7 @@ def main(args):
                             dataV[sid, count*readers[j].DATA_LENGTH:(count+1)*readers[j].DATA_LENGTH] = cFrame.payload.data
                             k += 1
                                                        
-                elif readers[j] is drx:
+                elif readers[j] in (drx, drx8):
                     ## DRX
                     k = 0
                     while k < beampols[j]*nFramesD:
@@ -420,7 +422,7 @@ def main(args):
                             cFrame = readers[j].read_frame_ci8(f)
                             buffers[j].append( cFrame )
                         except errors.SyncError:
-                            print(f"Error - DRX @ {i}, {j}")
+                            print(f"Error - {'DRX' if readers[j] is drx else 'DRX8'} @ {i}, {j}")
                             continue
                         except errors.EOFError:
                             done = True

--- a/superCorrelator.py
+++ b/superCorrelator.py
@@ -160,7 +160,7 @@ def main(args):
         try:
             bitDepths.append( junkFrame.header.bits_per_sample )
         except AttributeError:
-            bitDepths.append( 8 )
+            bitDepths.append( 8 if readers[i] is drx else 16 )
             
         # Setup the frame buffers
         if readers[i] is vdif:

--- a/superPulsarCorrelator.py
+++ b/superPulsarCorrelator.py
@@ -167,7 +167,7 @@ def main(args):
         try:
             bitDepths.append( junkFrame.header.bits_per_sample )
         except AttributeError:
-            bitDepths.append( 8 )
+            bitDepths.append( 8 if readers[i] is drx else 16 )
             
         # Setup the frame buffers
         if readers[i] is vdif:

--- a/superPulsarCorrelator.py
+++ b/superPulsarCorrelator.py
@@ -107,7 +107,7 @@ def main(args):
             junkFrame = readers[i].read_frame(fh[i], central_freq=header['OBSFREQ'], sample_rate=header['OBSBW']*2.0)
             readers[i].DATA_LENGTH = junkFrame.payload.data.size
             beam, pol = junkFrame.id
-        elif readers[i] in (drx, drx8):
+        else:
             junkFrame = readers[i].read_frame(fh[i])
             while junkFrame.header.decimation == 0:
                 junkFrame = readers[i].read_frame(fh[i])
@@ -152,7 +152,7 @@ def main(args):
                     cFreq1 = junkFrame.central_freq
                 else:
                     pass
-            elif readers[i] in (drx, drx8):
+            else:
                 junkFrame = readers[i].read_frame(fh[i])
                 b,t,p = junkFrame.id
                 if p == 0:
@@ -192,7 +192,7 @@ def main(args):
             
             nFramesFile[i] -= j
             
-        elif readers[i] in (drx, drx8):
+        else:
             pass
             
         # Align the files as close as possible by the time tags
@@ -284,8 +284,8 @@ def main(args):
     print(" ")
     
     nVDIFInputs = sum([1 for reader in readers if reader is vdif])
-    nDRXInputs = sum([1 for reader in readers if reader in (drx, drx8)])
-    print(f"Processing {nVDIFInputs} VDIF and {nDRXInputs} DRX/DRX8 input streams")
+    nDRXInputs = sum([1 for reader in readers if not reader is vdif])
+    print(f"Processing {nVDIFInputs} VDIF and {nDRXInputs} DRX or DRX8 input streams")
     print(" ")
     
     nFramesV = int(round(tRead*srate[0]/readers[0].DATA_LENGTH))
@@ -460,8 +460,8 @@ def main(args):
                             dataV[sid, count*readers[j].DATA_LENGTH:(count+1)*readers[j].DATA_LENGTH] = cFrame.payload.data
                             k += 1
                             
-                elif readers[j] in (drx, drx8):
-                    ## DRX
+                else:
+                    ## DRX/DRX8
                     k = 0
                     while k < beampols[j]*nFramesD:
                         try:

--- a/superPulsarCorrelator.py
+++ b/superPulsarCorrelator.py
@@ -25,9 +25,9 @@ from lsl.correlator import fx as fxc
 from lsl.writer import fitsidi
 from lsl.correlator.uvutils import compute_uvw
 
-from lsl.reader import drx, vdif, errors
+from lsl.reader import drx, drx8, vdif, errors
 from lsl.reader.base import FrameTimestamp
-from lsl.reader.buffer import DRXFrameBuffer, VDIFFrameBuffer
+from lsl.reader.buffer import DRXFrameBuffer, DRX8FrameBuffer, VDIFFrameBuffer
 from lsl.reader.base import CI8
 
 from lsl.misc.dedispersion import delay as dispDelay
@@ -107,7 +107,7 @@ def main(args):
             junkFrame = readers[i].read_frame(fh[i], central_freq=header['OBSFREQ'], sample_rate=header['OBSBW']*2.0)
             readers[i].DATA_LENGTH = junkFrame.payload.data.size
             beam, pol = junkFrame.id
-        elif readers[i] is drx:
+        elif readers[i] in (drx, drx8):
             junkFrame = readers[i].read_frame(fh[i])
             while junkFrame.header.decimation == 0:
                 junkFrame = readers[i].read_frame(fh[i])
@@ -121,7 +121,7 @@ def main(args):
         if readers[i] is vdif:
             tunepols.append( readers[i].get_thread_count(fh[i]) )
             beampols.append( tunepols[i] )
-        elif readers[i] is drx:
+        elif readers[i] is (drx, drx8):
             beampols.append( max(readers[i].get_frames_per_obs(fh[i])) )
             
         skip = args.skip + foffset
@@ -152,7 +152,7 @@ def main(args):
                     cFreq1 = junkFrame.central_freq
                 else:
                     pass
-            elif readers[i] is drx:
+            elif readers[i] in (drx, drx8):
                 junkFrame = readers[i].read_frame(fh[i])
                 b,t,p = junkFrame.id
                 if p == 0:
@@ -174,6 +174,8 @@ def main(args):
             buffers.append( VDIFFrameBuffer(threads=[0,1]) )
         elif readers[i] is drx:
             buffers.append( DRXFrameBuffer(beams=[beam,], tunes=[1,2], pols=[0,1], nsegments=16) )
+        elif readers[i] is drx8:
+            buffers.append( DRX8FrameBuffer(beams=[beam,], tunes=[1,2], pols=[0,1], nsegments=16) )
     for i in range(len(filenames)):
         # Align the files as close as possible by the time tags
         if readers[i] is vdif:
@@ -190,7 +192,7 @@ def main(args):
             
             nFramesFile[i] -= j
             
-        elif readers[i] is drx:
+        elif readers[i] in (drx, drx8):
             pass
             
         # Align the files as close as possible by the time tags
@@ -282,8 +284,8 @@ def main(args):
     print(" ")
     
     nVDIFInputs = sum([1 for reader in readers if reader is vdif])
-    nDRXInputs = sum([1 for reader in readers if reader is drx])
-    print(f"Processing {nVDIFInputs} VDIF and {nDRXInputs} DRX input streams")
+    nDRXInputs = sum([1 for reader in readers if reader in (drx, drx8)])
+    print(f"Processing {nVDIFInputs} VDIF and {nDRXInputs} DRX/DRX8 input streams")
     print(" ")
     
     nFramesV = int(round(tRead*srate[0]/readers[0].DATA_LENGTH))
@@ -458,7 +460,7 @@ def main(args):
                             dataV[sid, count*readers[j].DATA_LENGTH:(count+1)*readers[j].DATA_LENGTH] = cFrame.payload.data
                             k += 1
                             
-                elif readers[j] is drx:
+                elif readers[j] in (drx, drx8):
                     ## DRX
                     k = 0
                     while k < beampols[j]*nFramesD:
@@ -466,7 +468,7 @@ def main(args):
                             cFrame = readers[j].read_frame_ci8(f)
                             buffers[j].append( cFrame )
                         except errors.SyncError:
-                            print(f"Error - DRX @ {i}, {j}")
+                            print(f"Error - {'DRX' if readers[j] is drx else 'DRX8'} @ {i}, {j}")
                             continue
                         except errors.EOFError:
                             done = True

--- a/utils.py
+++ b/utils.py
@@ -18,7 +18,7 @@ from datetime import datetime
 
 from lsl import astro
 from lsl.common import stations
-from lsl.reader import base, drx, vdif
+from lsl.reader import base, drx, drx8, vdif
 from lsl.common.dp import fS
 from lsl.common.mcs import datetime_to_mjdmpm, delay_to_mcsd, mcsd_to_delay
 from lsl.common.metabundle import get_command_script
@@ -528,6 +528,8 @@ def _read_correlator_configuration(filename):
             readers.append( vdif )
         elif block['type'] == 'drx':
             readers.append( drx )
+        elif block['type'] == 'drx8':
+            readers.append( drx8 )
         else:
             readers.append( None )
             
@@ -666,14 +668,14 @@ def read_correlator_configuration(filename_or_npz):
 
 def get_better_time(frame):
     """
-    Given a lsl.reader.vdif.Frame or lsl.reader.drx.Frame instance, return a
-    more accurate time for the frame.  Unlike the Frame.get_time() functions,
-    this function returns a two-element tuple of:
+    Given a lsl.reader.vdif.Frame, lsl.reader.drx.Frame instance, or
+    lsl.reader.drx8.Frame, return a more accurate time for the frame.  Unlike the
+    Frame.get_time() functions, this function returns a two-element tuple of:
       * integer seconds since the UNIX epoch and
       * fractional second
     """
     
-    if isinstance(frame, drx.Frame):
+    if isinstance(frame, (drx.Frame, drx8.Frame)):
         # HACK - What should T_NOM really be at LWA1???
         tt = frame.payload.timetag
         to = 6660 if frame.header.time_offset else 0


### PR DESCRIPTION
With LSL 3.0.5 out we can now add support for DRX8 data as an input to the correlator.